### PR TITLE
Ubuntu 14.04 warnings & !compile

### DIFF
--- a/Scripts/Custom Systems/Referral Rewards/TellAFriend.cs
+++ b/Scripts/Custom Systems/Referral Rewards/TellAFriend.cs
@@ -18,7 +18,7 @@ namespace Server
 {
     public class TellAFriend
     {
-        public const bool Enabled = false;
+        public static bool Enabled = false;
         private const string TAFShardName = "Your Shard Name";
 
         public static void Initialize()


### PR DESCRIPTION
Ubuntu 14.04 if(!TellAFriend.Enabled)return;  cause these Unreachables codes
- Custom Systems/Referral Rewards/ReferralRewardItems.cs:
  CS0162: Line 86: Unreachable code detected
  - Custom Systems/Referral Rewards/ReferralRewardsStone.cs:
    CS0162: Line 36: Unreachable code detected
  - Custom Systems/Referral Rewards/TellAFriend.cs:
    CS0162: Line 31: Unreachable code detected
