### PR TITLE
Ambigous call on Ubuntu 14.04

### DIFF
--- a/Scripts/Services/XmlSpawner 2/XmlEngines/XmlSpawnerGumps.cs
+++ b/Scripts/Services/XmlSpawner 2/XmlEngines/XmlSpawnerGumps.cs
@@ -284,8 +284,8 @@ namespace Server.Mobiles
             this.AddImageTiled(23, 300, 214, 23, 0x52);
             this.AddImageTiled(24, 301, 213, 21, 0xBBC);
 
-            this.AddTextEntry(35, 275, 200, 21, 0, 1, null);
-            this.AddTextEntry(35, 300, 200, 21, 0, 2, null);
+            this.AddTextEntry(35, 275, 200, 21, 0, 1, (string)null);
+            this.AddTextEntry(35, 300, 200, 21, 0, 2, (string)null);
         }
 
         public override void OnResponse(NetState state, RelayInfo info)


### PR DESCRIPTION
 Services/XmlSpawner 2/XmlEngines/XmlSpawnerGumps.cs:
    CS0121: Line 287: The call is ambiguous between the following methods or properties: `Server.Gumps.Gump.AddTextEntry(int, int, int, int, int, int, string)' and`Server.Gumps.Gump.AddTextEntry(int, int, int, int, int, int, Server.Gumps.GumpResponse, string, string)'
    CS0121: Line 288: The call is ambiguous between the following methods or properties: `Server.Gumps.Gump.AddTextEntry(int, int, int, int, int, int, string)' and`Server.Gumps.Gump.AddTextEntry(int, int, int, int, int, int, Server.Gumps.GumpResponse, string, string)'
