### PR TITLE
Default Initialising m_SAAbsorptionAttributes

### DIFF
--- a/Scripts/Items/- BaseClasses/BaseJewel.cs
+++ b/Scripts/Items/- BaseClasses/BaseJewel.cs
@@ -764,6 +764,9 @@ namespace Server.Items
                     }
             }
 
+		if(this.m_SAAbsorptionAttributes==null)
+			this.m_SAAbsorptionAttributes = new SAAbsorptionAttributes(this);
+				
             #region Mondain's Legacy Sets
             if (this.m_SetAttributes == null)
                 this.m_SetAttributes = new AosAttributes(this);


### PR DESCRIPTION
In case booting on an older save/version<4  (not so far)

Or when saving after, crash due to NullException

(Will occurs too in BaseWeapon&BaseArmor with version<5 but is it really important ^^)
