### PR TITLE
Update ToxicSlith.cs

### DIFF
--- a/Scripts/Mobiles/Animals/Reptiles/ToxicSlith.cs
+++ b/Scripts/Mobiles/Animals/Reptiles/ToxicSlith.cs
@@ -88,19 +88,17 @@ namespace Server.Mobiles
                     case 2:
                         c.DropItem(new SlithEye());
                         break;
-
-                        if (Utility.RandomDouble() < 0.25)
-                        {
-                            switch (Utility.Random(2))
-                            {
-                                case 0:
-                                    c.DropItem(new AncientPotteryFragments());
-                                    break;
-                                case 1:
-                                    c.DropItem(new TatteredAncientScroll());
-                                    break;
-                            }
-                        }
+				}
+            }
+			
+			if (Utility.RandomDouble() < 0.25)
+            {
+				switch (Utility.Random(2))
+                {
+					case 0: c.DropItem(new AncientPotteryFragments());
+						break;
+                    case 1: c.DropItem(new TatteredAncientScroll());
+						break;
                 }
             }
         }


### PR DESCRIPTION
fixed unreachable code that was preventing mobile from dropping AncientPotteryFragments and TatteredAncientScroll