### PR TITLE
Allow opposing factions to fight when harmful map restrictions are in effect

### DIFF
--- a/Scripts/Misc/Notoriety.cs
+++ b/Scripts/Misc/Notoriety.cs
@@ -168,6 +168,18 @@ namespace Server.Misc
             if (from == null || target == null || from.IsStaff() || target.IsStaff())
                 return true;
 
+            Map map = from.Map;
+
+            #region Factions
+            Faction targetFaction = Faction.Find(target, true);
+
+            if ((!Core.ML || map == Faction.Facet) && targetFaction != null)
+            {
+                if (Faction.Find(from, true) != targetFaction)
+                    return true; // In factions, anything goes
+            }
+            #endregion
+
             #region Mondain's Legacy
             if (target is Gregorio)
             {
@@ -227,8 +239,6 @@ namespace Server.Misc
             if (sz != null /*&& sz.IsDisabled()*/)
                 return false;
             #endregion
-
-            Map map = from.Map;
 
             if (map != null && (map.Rules & MapRules.HarmfulRestrictions) == 0)
                 return true; // In felucca, anything goes


### PR DESCRIPTION
Allows opposing faction members to perform harmful actions on each other on the factions map even when the MapRestrictions.HarmfulRestrictions flag is set. This makes the behavior more consistent. The specific use case is to allow disabling non-consensual PvP on the faction map.